### PR TITLE
Add access to home

### DIFF
--- a/com.github.needleandthread.vocal.json
+++ b/com.github.needleandthread.vocal.json
@@ -34,6 +34,8 @@
 		"--own-name=com.github.needle-and-thread.vocal",
 
 		"--filesystem=/tmp"
+		
+		"--filesystem=home",
 	],
 	"build-options": {
 		"cflags": "-O2",


### PR DESCRIPTION
In order to use the 'import from OPML' feature we need to let the app see the location OPML files will be stored.